### PR TITLE
feat: add F-Droid metadata

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,0 +1,5 @@
+This is a Text-To-Speech (TTS) engine for the Klingon language (<pre>tlhIngan Hol</pre>) which can be used with <pre>boQwI'</pre> and other supported apps. It can be used with any web browser which supports the text selection action. (Chrome supports this, Firefox does not.) Look for it under your device's Text-To-Speech settings.
+
+This is a project of the Klingon Language Institute. Klingon, Star Trek, and related marks are trademarks of CBS Studios, Inc., and are used with permission through an arrangement with the KLI.
+
+<b>Note: This is NOT A STAND-ALONE APP itself and THERE IS NO APP ICON.</b>

--- a/fastlane/metadata/android/en-US/images/icon.png
+++ b/fastlane/metadata/android/en-US/images/icon.png
@@ -1,0 +1,1 @@
+../../../../../app/src/main/res/drawable/ic_ka.png

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,0 +1,1 @@
+Klingon TTS (Text-To-Speech) Engine for Android

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,0 +1,1 @@
+Klingon TTS add-on for boQwI'


### PR DESCRIPTION
Relating to https://github.com/De7vID/klingon-assistant-android/pull/160, I'd propose to also add the app metadata here. Since there are no community translations yet, it's a rather simple structure.